### PR TITLE
Stop using `nightly` channel for `stm32` crate

### DIFF
--- a/software/stm32/rust-toolchain.toml
+++ b/software/stm32/rust-toolchain.toml
@@ -1,3 +1,2 @@
 [toolchain]
-channel = "nightly-2022-04-22"
 targets = ["thumbv7m-none-eabi"]


### PR DESCRIPTION
Resolves #37

commit-id:c3aac06d
