### PR TITLE
`fishstick-stm32f103` dependency on `fishstick`

### DIFF
--- a/software/fishstick-stm32f103/Cargo.lock
+++ b/software/fishstick-stm32f103/Cargo.lock
@@ -30,6 +30,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "bxcan"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,12 +104,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "fishstick"
+version = "0.1.0"
+dependencies = [
+ "bitvec",
+ "cortex-m",
+ "cortex-m-rt",
+ "embedded-hal",
+ "nb 1.0.0",
+ "panic-halt",
+ "stm32f1xx-hal",
+]
+
+[[package]]
 name = "fishstick-stm32f103"
 version = "0.1.0"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
  "embedded-hal",
+ "fishstick",
  "nb 1.0.0",
  "panic-halt",
  "stm32f1xx-hal",
@@ -121,6 +147,12 @@ dependencies = [
  "fugit",
  "nb 1.0.0",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "gcd"
@@ -175,6 +207,12 @@ checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rustc_version"
@@ -261,6 +299,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,4 +335,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
 dependencies = [
  "vcell",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
+dependencies = [
+ "tap",
 ]

--- a/software/fishstick-stm32f103/Cargo.toml
+++ b/software/fishstick-stm32f103/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 cortex-m = "0.7.4"
 cortex-m-rt = "0.7.1"
 embedded-hal = "0.2.7"
+fishstick = { path = "../fishstick" }
 nb = "1.0.0"
 panic-halt = "0.2.0"
 

--- a/software/fishstick-stm32f103/src/main.rs
+++ b/software/fishstick-stm32f103/src/main.rs
@@ -7,6 +7,8 @@ use nb::block;
 use panic_halt as _;
 use stm32f1xx_hal::{pac, prelude::*, timer::Timer};
 
+use fishstick::joybus::Packet;
+
 #[entry]
 fn main() -> ! {
     // Get access to the core peripherals from the cortex-m crate

--- a/software/fishstick/src/lib.rs
+++ b/software/fishstick/src/lib.rs
@@ -1,2 +1,4 @@
+#![no_std]
+
 pub mod gamecube;
 pub mod joybus;


### PR DESCRIPTION
This makes the `fishstick-stm32f103` crate have a real dependency on the core `fishstick` crate

Resolves #51
