### PR TITLE
Sanity-check test for `fishstick` that runs on host machine

### DIFF
--- a/.idea/runConfigurations/test_fishstick.xml
+++ b/.idea/runConfigurations/test_fishstick.xml
@@ -1,0 +1,17 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="test fishstick" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="command" value="test" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$/software/fishstick" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="false" />
+    <option name="allFeatures" value="false" />
+    <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <envs />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/software/fishstick/src/lib.rs
+++ b/software/fishstick/src/lib.rs
@@ -1,4 +1,16 @@
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 
 pub mod gamecube;
 pub mod joybus;
+
+#[cfg(test)]
+mod tests {
+    extern crate alloc;
+    use alloc::vec;
+
+    #[test]
+    fn health_check() -> Result<(), ()> {
+        let _ = vec![1, 2, 3];
+        Ok(())
+    }
+}


### PR DESCRIPTION
Even though the test requires the `std` crate, the hardware crates can still use it at runtime.

Resolves #53
